### PR TITLE
✅ .NET code coverage

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,10 +1,10 @@
 {
+	"version": 1,
 	"isRoot": true,
 	"tools": {
 		"csharpier": {
-			"commands": ["dotnet-csharpier"],
-			"version": "0.28.2"
+			"version": "0.28.2",
+			"commands": ["dotnet-csharpier"]
 		}
-	},
-	"version": 1
+	}
 }

--- a/.config/project.json
+++ b/.config/project.json
@@ -6,6 +6,14 @@
 		"default": ["{workspaceRoot}/*", "{workspaceRoot}/.config/**/*"]
 	},
 	"targets": {
+		"clean": {
+			"//": "Customize to run on root/config files.",
+			"executor": "nx:run-commands",
+			"options": {
+				// shx if needed
+				"command": "rm -rf coverage"
+			}
+		},
 		"eslint": {
 			"//": "Customize to run on root/config files.",
 			"cache": true,

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+coverage/
 dist/
 node_modules/
 obj/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -54,6 +54,13 @@
 		<ErrorEndLocation>true</ErrorEndLocation> <!-- Tentative. I want to try this out. -->
 	</PropertyGroup>
 
+	<!-- Unit test coverage -->
+	<PropertyGroup Condition="$(MSBuildProjectName.EndsWith('test'))">
+		<!-- Recommended to disable if no C++ native code. -->
+		<EnableStaticNativeInstrumentation>False</EnableStaticNativeInstrumentation>
+		<EnableDynamicNativeInstrumentation>False</EnableDynamicNativeInstrumentation>
+	</PropertyGroup>
+
 	<!-- Unit test usings -->
 	<ItemGroup Condition="$(MSBuildProjectName.EndsWith('test'))">
 		<Using Include="FluentAssertions" />

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,10 +4,10 @@ export default [
 	...connorjsConfig,
 	{
 		// Customize JSONC rules for Nx files
-		files: [`nx.json`, `project.json`],
+		files: [`nx.json`, `**/project.json`],
 		rules: {
 			"jsonc/no-comments": `off`,
 		},
 	},
-	{ ignores: [`.nx`] },
+	{ ignores: [`.config/dotnet-tools.json`, `.nx`] },
 ];

--- a/libs/hello-cs/project.json
+++ b/libs/hello-cs/project.json
@@ -4,10 +4,10 @@
 	"projectType": "library",
 	"tags": ["dotnet"],
 	"targets": {
+		"build.net": {},
 		"clean": {},
+		"coverage.net": {},
 		"csharpier": {},
-		"dotnet build": {},
-		"dotnet test": {},
 		"eslint": {},
 		"prettier": {}
 	}

--- a/nx.json
+++ b/nx.json
@@ -18,6 +18,16 @@
 		"typescript": ["{projectRoot}/**/*.{ts,tsx}", "{projectRoot}/tsconfig.json"]
 	},
 	"targetDefaults": {
+		"build.net": {
+			"cache": true,
+			"dependsOn": ["^build.net"],
+			"executor": "nx:run-commands",
+			"inputs": ["rootDotnetConfig", "{projectRoot}/main/**/*"],
+			"options": {
+				"command": "dotnet build -c Release {projectRoot}/main"
+			},
+			"outputs": ["{projectRoot}/build/{projectName}.main"]
+		},
 		"clean": {
 			"cache": false,
 			"executor": "nx:run-commands",
@@ -31,36 +41,31 @@
 			// Create codegen target as a no-op, so that other `targetDefaults` can reference it
 			"executor": "nx:noop"
 		},
+		"coverage.net": {
+			"cache": true,
+			"dependsOn": ["build.net"],
+			"executor": "nx:run-commands",
+			"inputs": ["rootDotnetConfig", "{projectRoot}/test/**/*"],
+			"options": {
+				"commands": [
+					"dotnet run -c Release --project {projectRoot}/test --coverage --coverage-output {projectName}.cobertura.xml --coverage-output-format cobertura",
+					// shx if needed
+					"mkdir -p coverage",
+					"mv {projectRoot}/build/{projectName}.test/bin/{projectName}.test/release/TestResults/{projectName}.cobertura.xml coverage"
+				],
+				"parallel": false
+			},
+			"outputs": [
+				"{projectRoot}/build/{projectName}.test",
+				"{workspaceRoot}/coverage/{projectName}.cobertura.xml"
+			]
+		},
 		"csharpier": {
 			"cache": true,
 			"executor": "nx:run-commands",
 			"options": {
 				"command": "dotnet csharpier --check {projectRoot}"
 			}
-		},
-		"dotnet build": {
-			"cache": true,
-			"dependsOn": ["^dotnet build"],
-			"executor": "nx:run-commands",
-			"inputs": ["rootDotnetConfig", "{projectRoot}/main/**/*.{cs,csproj}"],
-			"options": {
-				"command": "dotnet build -c Release {projectRoot}/main"
-			},
-			"outputs": ["{projectRoot}/build/main"]
-		},
-		"dotnet test": {
-			"cache": true,
-			"dependsOn": ["dotnet build"],
-			"executor": "nx:run-commands",
-			"inputs": [
-				"rootDotnetConfig",
-				"{projectRoot}/{main,test}/**/*.{cs,csproj}",
-				"{projectRoot}/build/main"
-			],
-			"options": {
-				"command": "dotnet test -c Release {projectRoot}/test"
-			},
-			"outputs": ["{projectRoot}/build/test"]
 		},
 		"eslint": {
 			"cache": true,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"ci-build": "nx run-many -t 'build,csharpier,dotnet build,dotnet test,eslint,prettier,tsc' --exclude root",
+		"ci-build": "nx run-many -t 'build,build.net,coverage.net,csharpier,eslint,prettier,tsc' --exclude root",
 		"prepare": "is-ci || husky husky"
 	},
 	"dependencies": {

--- a/root.esproj
+++ b/root.esproj
@@ -9,5 +9,6 @@
 		<Script Include=".config\ts\README.md" />
 		<Script Include=".config\ts\tsconfig.json" />
 		<Script Include=".github\workflows\ci.yaml" />
+		<Script Include="tsconfig.json" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Configures .NET code coverage. Renames `dotnet build` and `dotnet test` to `build.net` and `coverage.net`, respectively to simplify command line typing (no space).

Modifies config files based on exploration during this change (example: Nx name to the top).