### PR TITLE
✅ Vitest for JS/TS

### DIFF
--- a/apps/web/project.json
+++ b/apps/web/project.json
@@ -21,6 +21,7 @@
 			},
 			"outputs": ["{projectRoot}/**/*.d.css.ts"]
 		},
+		"coverage.vitest": {},
 		"dev": {
 			"command": "vite {projectRoot}",
 			"dependsOn": ["codegen"]

--- a/apps/web/src/pages/home/home.test.tsx
+++ b/apps/web/src/pages/home/home.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Home } from "~/pages/home/home.tsx";
+
+describe(`home`, () => {
+	it(`should render hello`, () => {
+		render(<Home />);
+		expect(screen.getByText(/hello/i)).toBeInTheDocument();
+	});
+});

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,16 +1,15 @@
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-
+import { vitestConfig } from "@connorjs/nx-polyglot-example-vitest";
 import react from "@vitejs/plugin-react-swc";
 import type { GetManualChunk } from "rollup";
 import { visualizer } from "rollup-plugin-visualizer";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = import.meta.dirname;
 
 // https://vitejs.dev/config/
 export default defineConfig({
+	...vitestConfig(projectRoot),
 	build: {
 		rollupOptions: {
 			output: {
@@ -31,7 +30,7 @@ export default defineConfig({
 		// Visualizer should be last
 		visualizer({
 			brotliSize: true,
-			filename: `${__dirname}/build/stats.json`,
+			filename: `${projectRoot}/build/stats.json`,
 			template: `raw-data`, // Used by `visualize` target
 		}),
 	],

--- a/libs/hello-js/project.json
+++ b/libs/hello-js/project.json
@@ -5,6 +5,7 @@
 	"sourceRoot": "libs/hello-js/src",
 	"targets": {
 		"clean": {},
+		"coverage.vitest": {},
 		"eslint": {},
 		"prettier": {},
 		"tsc": {}

--- a/libs/hello-js/src/hello.test.ts
+++ b/libs/hello-js/src/hello.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { hello } from "./hello.ts";
+
+describe(`hello`, () => {
+	it.each([
+		[undefined, `Hello, world!`],
+		[``, `Hello, world!`],
+		[` `, `Hello,  !`],
+		[`foo`, `Hello, foo!`],
+	])(`should map [%s] to [%s]`, (input, expected) => {
+		expect(hello(input)).toStrictEqual(expected);
+	});
+
+	it(`does not require an argument`, () => {
+		expect(hello()).toBe(`Hello, world!`);
+	});
+});

--- a/libs/hello-js/tsconfig.json
+++ b/libs/hello-js/tsconfig.json
@@ -1,5 +1,5 @@
 {
 	"compilerOptions": { "baseUrl": ".", "outDir": "./build/tsc" },
 	"extends": "../../tsconfig.options.json",
-	"include": ["src"]
+	"include": ["src", "vitest.config.ts"]
 }

--- a/libs/hello-js/vitest.config.ts
+++ b/libs/hello-js/vitest.config.ts
@@ -1,0 +1,3 @@
+import { vitestConfig } from "@connorjs/nx-polyglot-example-vitest";
+
+export default vitestConfig(import.meta.dirname);

--- a/nx.json
+++ b/nx.json
@@ -13,7 +13,8 @@
 		],
 		"rootTsConfig": [
 			"{workspaceRoot}/.config/ts/tsconfig.json",
-			"{workspaceRoot}/tsconfig.json"
+			"{workspaceRoot}/tsconfig.json",
+			"{workspaceRoot}/tsconfig.options.json"
 		],
 		"typescript": ["{projectRoot}/**/*.{ts,tsx}", "{projectRoot}/tsconfig.json"]
 	},
@@ -59,6 +60,16 @@
 				"{projectRoot}/build/{projectName}.test",
 				"{workspaceRoot}/coverage/{projectName}.cobertura.xml"
 			]
+		},
+		"coverage.vitest": {
+			"cache": true,
+			"dependsOn": ["^tsc", "codegen"],
+			"executor": "nx:run-commands",
+			"inputs": ["rootTsConfig", "default", "{workspaceRoot}/vitest.config.ts"],
+			"options": {
+				"command": "vitest run --coverage --root {projectRoot}"
+			},
+			"outputs": ["{workspaceRoot}/coverage/{projectName}.cobertura.xml"]
 		},
 		"csharpier": {
 			"cache": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,19 +5,28 @@
 	"packages": {
 		"": {
 			"name": "@connorjs/nx-polyglot-example",
+			"workspaces": [
+				"tools/*"
+			],
 			"dependencies": {
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1"
 			},
 			"devDependencies": {
+				"@connorjs/nx-polyglot-example-vitest": "*",
 				"@prettier/plugin-xml": "^3.4.1",
+				"@testing-library/jest-dom": "^6.4.5",
+				"@testing-library/react": "^15.0.7",
+				"@testing-library/user-event": "^14.5.2",
 				"@types/react": "^18.3.2",
 				"@types/react-dom": "^18.3.0",
 				"@vitejs/plugin-react-swc": "^3.6.0",
+				"@vitest/coverage-v8": "^1.6.0",
 				"css-typed": "~0.2.3",
 				"eslint": "^8.57.0",
 				"eslint-config-connorjs": "^1.0.0-alpha.7",
 				"eslint-formatter-pretty": "^6.0.1",
+				"happy-dom": "^14.10.1",
 				"husky": "^9.0.11",
 				"is-ci": "^3.0.1",
 				"lint-staged": "^15.2.2",
@@ -27,15 +36,21 @@
 				"rollup-plugin-visualizer": "^5.12.0",
 				"typescript": "^5.4.5",
 				"vite": "^5.2.11",
-				"vite-tsconfig-paths": "^4.3.2"
+				"vite-tsconfig-paths": "^4.3.2",
+				"vitest": "^1.6.0"
 			}
+		},
+		"node_modules/@adobe/css-tools": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.3.tgz",
+			"integrity": "sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==",
+			"dev": true
 		},
 		"node_modules/@ampproject/remapping": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
 			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.24"
@@ -468,6 +483,16 @@
 			"engines": {
 				"node": ">=6.9.0"
 			}
+		},
+		"node_modules/@bcoe/v8-coverage": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+			"dev": true
+		},
+		"node_modules/@connorjs/nx-polyglot-example-vitest": {
+			"resolved": "tools/vitest",
+			"link": true
 		},
 		"node_modules/@esbuild/aix-ppc64": {
 			"version": "0.20.2",
@@ -1366,6 +1391,15 @@
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
+		"node_modules/@istanbuljs/schema": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+			"integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/@jest/schemas": {
 			"version": "29.6.3",
 			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -2128,6 +2162,164 @@
 				"@swc/counter": "^0.1.3"
 			}
 		},
+		"node_modules/@testing-library/dom": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.1.0.tgz",
+			"integrity": "sha512-wdsYKy5zupPyLCW2Je5DLHSxSfbIp6h80WoHOQc+RPtmPGA52O9x5MJEkv92Sjonpq+poOAtUKhh1kBGAXBrNA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/runtime": "^7.12.5",
+				"@types/aria-query": "^5.0.1",
+				"aria-query": "5.3.0",
+				"chalk": "^4.1.0",
+				"dom-accessibility-api": "^0.5.9",
+				"lz-string": "^1.5.0",
+				"pretty-format": "^27.0.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/pretty-format": {
+			"version": "27.5.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1",
+				"ansi-styles": "^5.0.0",
+				"react-is": "^17.0.1"
+			},
+			"engines": {
+				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/react-is": {
+			"version": "17.0.2",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+			"dev": true
+		},
+		"node_modules/@testing-library/jest-dom": {
+			"version": "6.4.5",
+			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.4.5.tgz",
+			"integrity": "sha512-AguB9yvTXmCnySBP1lWjfNNUwpbElsaQ567lt2VdGqAdHtpieLgjmcVyv1q7PMIvLbgpDdkWV5Ydv3FEejyp2A==",
+			"dev": true,
+			"dependencies": {
+				"@adobe/css-tools": "^4.3.2",
+				"@babel/runtime": "^7.9.2",
+				"aria-query": "^5.0.0",
+				"chalk": "^3.0.0",
+				"css.escape": "^1.5.1",
+				"dom-accessibility-api": "^0.6.3",
+				"lodash": "^4.17.21",
+				"redent": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=14",
+				"npm": ">=6",
+				"yarn": ">=1"
+			},
+			"peerDependencies": {
+				"@jest/globals": ">= 28",
+				"@types/bun": "latest",
+				"@types/jest": ">= 28",
+				"jest": ">= 28",
+				"vitest": ">= 0.32"
+			},
+			"peerDependenciesMeta": {
+				"@jest/globals": {
+					"optional": true
+				},
+				"@types/bun": {
+					"optional": true
+				},
+				"@types/jest": {
+					"optional": true
+				},
+				"jest": {
+					"optional": true
+				},
+				"vitest": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@testing-library/jest-dom/node_modules/chalk": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+			"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+			"integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+			"dev": true
+		},
+		"node_modules/@testing-library/react": {
+			"version": "15.0.7",
+			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-15.0.7.tgz",
+			"integrity": "sha512-cg0RvEdD1TIhhkm1IeYMQxrzy0MtUNfa3minv4MjbgcYzJAZ7yD0i0lwoPOTPr+INtiXFezt2o8xMSnyHhEn2Q==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.12.5",
+				"@testing-library/dom": "^10.0.0",
+				"@types/react-dom": "^18.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.0.0",
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@testing-library/user-event": {
+			"version": "14.5.2",
+			"resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+			"integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=12",
+				"npm": ">=6"
+			},
+			"peerDependencies": {
+				"@testing-library/dom": ">=7.21.4"
+			}
+		},
+		"node_modules/@types/aria-query": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+			"dev": true
+		},
 		"node_modules/@types/eslint": {
 			"version": "8.56.10",
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
@@ -2479,6 +2671,129 @@
 				"vite": "^4 || ^5"
 			}
 		},
+		"node_modules/@vitest/coverage-v8": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-1.6.0.tgz",
+			"integrity": "sha512-KvapcbMY/8GYIG0rlwwOKCVNRc0OL20rrhFkg/CHNzncV03TE2XWvO5w9uZYoxNiMEBacAJt3unSOiZ7svePew==",
+			"dev": true,
+			"dependencies": {
+				"@ampproject/remapping": "^2.2.1",
+				"@bcoe/v8-coverage": "^0.2.3",
+				"debug": "^4.3.4",
+				"istanbul-lib-coverage": "^3.2.2",
+				"istanbul-lib-report": "^3.0.1",
+				"istanbul-lib-source-maps": "^5.0.4",
+				"istanbul-reports": "^3.1.6",
+				"magic-string": "^0.30.5",
+				"magicast": "^0.3.3",
+				"picocolors": "^1.0.0",
+				"std-env": "^3.5.0",
+				"strip-literal": "^2.0.0",
+				"test-exclude": "^6.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"vitest": "1.6.0"
+			}
+		},
+		"node_modules/@vitest/expect": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.0.tgz",
+			"integrity": "sha512-ixEvFVQjycy/oNgHjqsL6AZCDduC+tflRluaHIzKIsdbzkLn2U/iBnVeJwB6HsIjQBdfMR8Z0tRxKUsvFJEeWQ==",
+			"dev": true,
+			"dependencies": {
+				"@vitest/spy": "1.6.0",
+				"@vitest/utils": "1.6.0",
+				"chai": "^4.3.10"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.0.tgz",
+			"integrity": "sha512-P4xgwPjwesuBiHisAVz/LSSZtDjOTPYZVmNAnpHHSR6ONrf8eCJOFRvUwdHn30F5M1fxhqtl7QZQUk2dprIXAg==",
+			"dev": true,
+			"dependencies": {
+				"@vitest/utils": "1.6.0",
+				"p-limit": "^5.0.0",
+				"pathe": "^1.1.1"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner/node_modules/p-limit": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+			"integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+			"dev": true,
+			"dependencies": {
+				"yocto-queue": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@vitest/runner/node_modules/yocto-queue": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+			"integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.0.tgz",
+			"integrity": "sha512-+Hx43f8Chus+DCmygqqfetcAZrDJwvTj0ymqjQq4CvmpKFSTVteEOBzCusu1x2tt4OJcvBflyHUE0DZSLgEMtQ==",
+			"dev": true,
+			"dependencies": {
+				"magic-string": "^0.30.5",
+				"pathe": "^1.1.1",
+				"pretty-format": "^29.7.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.0.tgz",
+			"integrity": "sha512-leUTap6B/cqi/bQkXUu6bQV5TZPx7pmMBKBQiI0rJA8c3pB56ZsaTbREnF7CJfmvAS4V2cXIBAh/3rVwrrCYgw==",
+			"dev": true,
+			"dependencies": {
+				"tinyspy": "^2.2.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.0.tgz",
+			"integrity": "sha512-21cPiuGMoMZwiOHa2i4LXkMkMkCGzA+MVFV70jRwHo95dL4x/ts5GZhML1QWuy7yfp3WzK3lRvZi3JnXTYqrBw==",
+			"dev": true,
+			"dependencies": {
+				"diff-sequences": "^29.6.3",
+				"estree-walker": "^3.0.3",
+				"loupe": "^2.3.7",
+				"pretty-format": "^29.7.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
 		"node_modules/@whatwg-node/events": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.0.3.tgz",
@@ -2592,6 +2907,15 @@
 			"dev": true,
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/acorn-walk": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+			"integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/ajv": {
@@ -2861,6 +3185,15 @@
 				"node": ">=12.0.0"
 			}
 		},
+		"node_modules/assertion-error": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+			"dev": true,
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/ast-types-flow": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -3056,6 +3389,15 @@
 				"node": ">=10.16.0"
 			}
 		},
+		"node_modules/cac": {
+			"version": "6.7.14",
+			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/call-bind": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
@@ -3104,6 +3446,24 @@
 				}
 			]
 		},
+		"node_modules/chai": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
+			"integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
+			"dev": true,
+			"dependencies": {
+				"assertion-error": "^1.1.0",
+				"check-error": "^1.0.3",
+				"deep-eql": "^4.1.3",
+				"get-func-name": "^2.0.2",
+				"loupe": "^2.3.6",
+				"pathval": "^1.1.1",
+				"type-detect": "^4.0.8"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3118,6 +3478,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/check-error": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+			"integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+			"dev": true,
+			"dependencies": {
+				"get-func-name": "^2.0.2"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/chevrotain": {
@@ -3328,6 +3700,12 @@
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true
 		},
+		"node_modules/confbox": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.7.tgz",
+			"integrity": "sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA==",
+			"dev": true
+		},
 		"node_modules/convert-source-map": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -3405,6 +3783,12 @@
 			"engines": {
 				"node": ">=16"
 			}
+		},
+		"node_modules/css.escape": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+			"integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+			"dev": true
 		},
 		"node_modules/csstype": {
 			"version": "3.1.3",
@@ -3490,6 +3874,18 @@
 				"supports-color": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/deep-eql": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+			"integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+			"dev": true,
+			"dependencies": {
+				"type-detect": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/deep-is": {
@@ -3604,6 +4000,12 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/dom-accessibility-api": {
+			"version": "0.5.16",
+			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+			"dev": true
+		},
 		"node_modules/dotenv": {
 			"version": "16.3.2",
 			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.2.tgz",
@@ -3677,6 +4079,18 @@
 			},
 			"engines": {
 				"node": ">=8.6"
+			}
+		},
+		"node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/error-ex": {
@@ -4584,6 +4998,15 @@
 				"node": ">=4.0"
 			}
 		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4972,6 +5395,15 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/get-func-name": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+			"integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+			"dev": true,
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/get-intrinsic": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
@@ -5239,6 +5671,29 @@
 				"graphql": ">=0.11 <=16"
 			}
 		},
+		"node_modules/happy-dom": {
+			"version": "14.10.1",
+			"resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-14.10.1.tgz",
+			"integrity": "sha512-GRbrZYIezi8+tTtffF4v2QcF8bk1h2loUTO5VYQz3GZdrL08Vk0fI+bwf/vFEBf4C/qVf/easLJ/MY1wwdhytA==",
+			"dev": true,
+			"dependencies": {
+				"entities": "^4.5.0",
+				"webidl-conversions": "^7.0.0",
+				"whatwg-mimetype": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/happy-dom/node_modules/webidl-conversions": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/has-bigints": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -5324,6 +5779,12 @@
 			"version": "2.8.9",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
 			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+			"dev": true
+		},
+		"node_modules/html-escaper": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
 			"dev": true
 		},
 		"node_modules/human-signals": {
@@ -5948,6 +6409,56 @@
 				"ws": "*"
 			}
 		},
+		"node_modules/istanbul-lib-coverage": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+			"integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/istanbul-lib-report": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+			"integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+			"dev": true,
+			"dependencies": {
+				"istanbul-lib-coverage": "^3.0.0",
+				"make-dir": "^4.0.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-lib-source-maps": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.4.tgz",
+			"integrity": "sha512-wHOoEsNJTVltaJp8eVkm8w+GVkVNHT2YDYo53YdzQEL2gWm1hBX5cGFR9hQJtuGLebidVX7et3+dmDZrmclduw==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.23",
+				"debug": "^4.1.1",
+				"istanbul-lib-coverage": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-reports": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+			"integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+			"dev": true,
+			"dependencies": {
+				"html-escaper": "^2.0.0",
+				"istanbul-lib-report": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/iterator.prototype": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.2.tgz",
@@ -6310,6 +6821,22 @@
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
+		"node_modules/local-pkg": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.0.tgz",
+			"integrity": "sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==",
+			"dev": true,
+			"dependencies": {
+				"mlly": "^1.4.2",
+				"pkg-types": "^1.0.3"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			}
+		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -6324,6 +6851,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"dev": true
 		},
 		"node_modules/lodash.lowercase": {
 			"version": "4.3.0",
@@ -6482,6 +7015,15 @@
 				"loose-envify": "cli.js"
 			}
 		},
+		"node_modules/loupe": {
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+			"integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+			"dev": true,
+			"dependencies": {
+				"get-func-name": "^2.0.1"
+			}
+		},
 		"node_modules/lru-cache": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -6490,6 +7032,62 @@
 			"peer": true,
 			"dependencies": {
 				"yallist": "^3.0.2"
+			}
+		},
+		"node_modules/lz-string": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+			"dev": true,
+			"bin": {
+				"lz-string": "bin/bin.js"
+			}
+		},
+		"node_modules/magic-string": {
+			"version": "0.30.10",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
+			"integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.4.15"
+			}
+		},
+		"node_modules/magicast": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.4.tgz",
+			"integrity": "sha512-TyDF/Pn36bBji9rWKHlZe+PZb6Mx5V8IHCSxk7X4aljM4e/vyDvZZYwHewdVaqiA0nb3ghfHU/6AUpDxWoER2Q==",
+			"dev": true,
+			"dependencies": {
+				"@babel/parser": "^7.24.4",
+				"@babel/types": "^7.24.0",
+				"source-map-js": "^1.2.0"
+			}
+		},
+		"node_modules/make-dir": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+			"integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+			"dev": true,
+			"dependencies": {
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/make-dir/node_modules/semver": {
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/mdn-data": {
@@ -6613,6 +7211,18 @@
 			"dev": true,
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/mlly": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.0.tgz",
+			"integrity": "sha512-U9SDaXGEREBYQgfejV97coK0UL1r+qnF2SyO9A3qcI8MzKnsIFKHNVEkrDyNncQTKQQumsasmeq84eNMdBfsNQ==",
+			"dev": true,
+			"dependencies": {
+				"acorn": "^8.11.3",
+				"pathe": "^1.1.2",
+				"pkg-types": "^1.1.0",
+				"ufo": "^1.5.3"
 			}
 		},
 		"node_modules/ms": {
@@ -7384,6 +7994,21 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/pathe": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+			"integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+			"dev": true
+		},
+		"node_modules/pathval": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+			"integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+			"dev": true,
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/picocolors": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -7412,6 +8037,17 @@
 			},
 			"engines": {
 				"node": ">=0.10"
+			}
+		},
+		"node_modules/pkg-types": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.1.1.tgz",
+			"integrity": "sha512-ko14TjmDuQJ14zsotODv7dBlwxKhUKQEhuhmbqo1uCi9BB0Z2alo/wAXg6q1dTR5TyuqYyWhjtfe/Tsh+X28jQ==",
+			"dev": true,
+			"dependencies": {
+				"confbox": "^0.1.7",
+				"mlly": "^1.7.0",
+				"pathe": "^1.1.2"
 			}
 		},
 		"node_modules/plur": {
@@ -7735,6 +8371,19 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/redent": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+			"integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+			"dev": true,
+			"dependencies": {
+				"indent-string": "^4.0.0",
+				"strip-indent": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/reflect.getprototypeof": {
@@ -8183,6 +8832,12 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true
+		},
 		"node_modules/signal-exit": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -8286,6 +8941,18 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+			"dev": true
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true
+		},
+		"node_modules/std-env": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",
+			"integrity": "sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==",
 			"dev": true
 		},
 		"node_modules/streamsearch": {
@@ -8546,6 +9213,24 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/strip-literal": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.0.tgz",
+			"integrity": "sha512-Op+UycaUt/8FbN/Z2TWPBLge3jWrP3xj10f3fnYxf052bKuS3EKs1ZQcVGjnEMdsNVAM+plXRdmjrZ/KgG3Skw==",
+			"dev": true,
+			"dependencies": {
+				"js-tokens": "^9.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			}
+		},
+		"node_modules/strip-literal/node_modules/js-tokens": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.0.tgz",
+			"integrity": "sha512-WriZw1luRMlmV3LGJaR6QOJjWwgLUTf89OwT2lUOyjX2dJGBwgmIkbcz+7WFZjrZM635JOIR517++e/67CP9dQ==",
+			"dev": true
+		},
 		"node_modules/strong-log-transformer": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz",
@@ -8628,6 +9313,40 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/test-exclude": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+			"integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+			"dev": true,
+			"dependencies": {
+				"@istanbuljs/schema": "^0.1.2",
+				"glob": "^7.1.4",
+				"minimatch": "^3.0.4"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/test-exclude/node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"dev": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -8639,6 +9358,30 @@
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
 			"dev": true
+		},
+		"node_modules/tinybench": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.8.0.tgz",
+			"integrity": "sha512-1/eK7zUnIklz4JUUlL+658n58XO2hHLQfSk1Zf2LKieUjxidN16eKFEoDEfjHc3ohofSSqK3X5yO6VGb6iW8Lw==",
+			"dev": true
+		},
+		"node_modules/tinypool": {
+			"version": "0.8.4",
+			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+			"integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tinyspy": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+			"integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+			"dev": true,
+			"engines": {
+				"node": ">=14.0.0"
+			}
 		},
 		"node_modules/tmp": {
 			"version": "0.2.3",
@@ -8748,6 +9491,15 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/type-detect": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/type-fest": {
@@ -8873,6 +9625,12 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/ufo": {
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.3.tgz",
+			"integrity": "sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw==",
+			"dev": true
 		},
 		"node_modules/unbox-primitive": {
 			"version": "1.0.2",
@@ -9050,6 +9808,28 @@
 				}
 			}
 		},
+		"node_modules/vite-node": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.0.tgz",
+			"integrity": "sha512-de6HJgzC+TFzOu0NTC4RAIsyf/DY/ibWDYQUcuEA84EMHhcefTUGkjFHKKEJhQN4A+6I0u++kr3l36ZF2d7XRw==",
+			"dev": true,
+			"dependencies": {
+				"cac": "^6.7.14",
+				"debug": "^4.3.4",
+				"pathe": "^1.1.1",
+				"picocolors": "^1.0.0",
+				"vite": "^5.0.0"
+			},
+			"bin": {
+				"vite-node": "vite-node.mjs"
+			},
+			"engines": {
+				"node": "^18.0.0 || >=20.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
 		"node_modules/vite-tsconfig-paths": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-4.3.2.tgz",
@@ -9065,6 +9845,71 @@
 			},
 			"peerDependenciesMeta": {
 				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vitest": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.0.tgz",
+			"integrity": "sha512-H5r/dN06swuFnzNFhq/dnz37bPXnq8xB2xB5JOVk8K09rUtoeNN+LHWkoQ0A/i3hvbUKKcCei9KpbxqHMLhLLA==",
+			"dev": true,
+			"dependencies": {
+				"@vitest/expect": "1.6.0",
+				"@vitest/runner": "1.6.0",
+				"@vitest/snapshot": "1.6.0",
+				"@vitest/spy": "1.6.0",
+				"@vitest/utils": "1.6.0",
+				"acorn-walk": "^8.3.2",
+				"chai": "^4.3.10",
+				"debug": "^4.3.4",
+				"execa": "^8.0.1",
+				"local-pkg": "^0.5.0",
+				"magic-string": "^0.30.5",
+				"pathe": "^1.1.1",
+				"picocolors": "^1.0.0",
+				"std-env": "^3.5.0",
+				"strip-literal": "^2.0.0",
+				"tinybench": "^2.5.1",
+				"tinypool": "^0.8.3",
+				"vite": "^5.0.0",
+				"vite-node": "1.6.0",
+				"why-is-node-running": "^2.2.2"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^18.0.0 || >=20.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@types/node": "^18.0.0 || >=20.0.0",
+				"@vitest/browser": "1.6.0",
+				"@vitest/ui": "1.6.0",
+				"happy-dom": "*",
+				"jsdom": "*"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
 					"optional": true
 				}
 			}
@@ -9105,6 +9950,15 @@
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
 			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
 			"dev": true
+		},
+		"node_modules/whatwg-mimetype": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+			"integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			}
 		},
 		"node_modules/whatwg-url": {
 			"version": "5.0.0",
@@ -9208,6 +10062,22 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.2.2.tgz",
+			"integrity": "sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==",
+			"dev": true,
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/word-wrap": {
@@ -9458,6 +10328,7 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		}
+		},
+		"tools/vitest": {}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"ci-build": "nx run-many -t 'build,build.net,coverage.net,csharpier,eslint,prettier,tsc' --exclude root",
+		"ci-build": "nx run-many -t 'build,build.net,coverage.net,coverage.vitest,csharpier,eslint,prettier,tsc' --exclude root",
 		"prepare": "is-ci || husky husky"
 	},
 	"dependencies": {
@@ -12,14 +12,20 @@
 		"react-dom": "^18.3.1"
 	},
 	"devDependencies": {
+		"@connorjs/nx-polyglot-example-vitest": "*",
 		"@prettier/plugin-xml": "^3.4.1",
+		"@testing-library/jest-dom": "^6.4.5",
+		"@testing-library/react": "^15.0.7",
+		"@testing-library/user-event": "^14.5.2",
 		"@types/react": "^18.3.2",
 		"@types/react-dom": "^18.3.0",
 		"@vitejs/plugin-react-swc": "^3.6.0",
+		"@vitest/coverage-v8": "^1.6.0",
 		"css-typed": "~0.2.3",
 		"eslint": "^8.57.0",
 		"eslint-config-connorjs": "^1.0.0-alpha.7",
 		"eslint-formatter-pretty": "^6.0.1",
+		"happy-dom": "^14.10.1",
 		"husky": "^9.0.11",
 		"is-ci": "^3.0.1",
 		"lint-staged": "^15.2.2",
@@ -29,6 +35,10 @@
 		"rollup-plugin-visualizer": "^5.12.0",
 		"typescript": "^5.4.5",
 		"vite": "^5.2.11",
-		"vite-tsconfig-paths": "^4.3.2"
-	}
+		"vite-tsconfig-paths": "^4.3.2",
+		"vitest": "^1.6.0"
+	},
+	"workspaces": [
+		"tools/*"
+	]
 }

--- a/tools/vitest/package.json
+++ b/tools/vitest/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "@connorjs/nx-polyglot-example-vitest",
+	"type": "module",
+	"exports": {
+		".": "./vitest.config.js",
+		"./dom-setup": "./vitest-dom-setup.mjs"
+	},
+	"types": "./vitest.config.d.ts"
+}

--- a/tools/vitest/project.json
+++ b/tools/vitest/project.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "../../node_modules/nx/schemas/project-schema.json",
+	"name": "vitest",
+	"projectType": "application",
+	"sourceRoot": "tools/vitest",
+	"targets": {
+		"prettier": {}
+	}
+}

--- a/tools/vitest/vitest-dom-setup.js
+++ b/tools/vitest/vitest-dom-setup.js
@@ -1,0 +1,6 @@
+import "@testing-library/jest-dom/vitest";
+
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+globalThis.document && afterEach(cleanup);

--- a/tools/vitest/vitest.config.d.ts
+++ b/tools/vitest/vitest.config.d.ts
@@ -1,0 +1,3 @@
+export function vitestConfig(projectRoot: string): {
+	test: import("vitest").UserConfig;
+};

--- a/tools/vitest/vitest.config.js
+++ b/tools/vitest/vitest.config.js
@@ -1,0 +1,44 @@
+import path from "node:path";
+
+import {
+	configDefaults,
+	coverageConfigDefaults,
+	defineConfig,
+} from "vitest/config";
+
+const vitestToolsRoot = import.meta.dirname;
+const workspaceRoot = path.resolve(vitestToolsRoot, `../..`);
+
+export function vitestConfig(projectRoot) {
+	const projectName = path.basename(projectRoot);
+	return defineConfig({
+		server: { fs: { allow: [vitestToolsRoot] } },
+		test: {
+			coverage: {
+				all: true,
+				clean: false, // Workspace-wide coverage directory; do not clean
+				exclude: [
+					...coverageConfigDefaults.exclude,
+					`**/*.d{,.css}.ts`, // Ignore type definitions
+					`**/*.stories.{ts,tsx}`, // Storybook stories
+					`**/export.ts`, // Expo${projectRoot}/rt files should just export
+				],
+				include: [`src`],
+				provider: `v8`,
+				reporter: [[`cobertura`, { file: `${projectName}.cobertura.xml` }]],
+				reportsDirectory: `${workspaceRoot}/coverage`,
+				thresholds: {
+					branches: 80,
+					functions: 100,
+					lines: 80,
+					perFile: true,
+				},
+			},
+			environmentMatchGlobs: [[`**/*.tsx`, `happy-dom`]],
+			exclude: [...configDefaults.exclude, `**/build/**`],
+			reporters: [`dot`], // Unit test reporter (not coverage)
+			restoreMocks: true,
+			setupFiles: `${vitestToolsRoot}/vitest-dom-setup.js`,
+		},
+	});
+}

--- a/tsconfig.options.json
+++ b/tsconfig.options.json
@@ -17,7 +17,8 @@
 		"paths": {
 			":hello-js/*": ["../../libs/hello-js/src/*"],
 			"~/*": ["./src/*"]
-		}
+		},
+		"types": ["@testing-library/jest-dom/vitest"]
 	},
 	"extends": "./.config/ts/tsconfig.json"
 }


### PR DESCRIPTION
Adds vitest for JS/TS unit testing. Organizes reusable vitest logic in a new tools project. The tools/vitest project has a package.json to simplify usage for new JS libraries. Includes happy-dom and testing library for UI unit testing.